### PR TITLE
Remove need of NGINX and root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
-FROM nginx:alpine
+FROM busybox
+
 LABEL maintainer="Jeroen Pardon"
 
-RUN apk add nano
+WORKDIR /opt/html
 
-RUN rm -rf /usr/share/nginx/html
-COPY . /usr/share/nginx/html
+COPY . /opt/html
 
 EXPOSE 80
+
+ENTRYPOINT [ "httpd", "-f", "-v", "-u", "1000" ]


### PR DESCRIPTION
Example how to run:

```
docker run \
    -d \
    -p 4000:80 \
    --cap-add=setuid \
sui
```

Busybox has an httpd function, and this brings the size down greatly. :)