### PR TITLE
Allow protocol in config, default to https://

### DIFF
--- a/app/assets/js/helpers.js
+++ b/app/assets/js/helpers.js
@@ -1,0 +1,12 @@
+Handlebars.registerHelper('cleanurl', function(url) {
+    var cleanurl = url.replace(/.*:\/\//,'').split(/[?#]/);
+    return new Handlebars.SafeString(cleanurl)
+});
+
+Handlebars.registerHelper('addprotocol', function(url) {
+    if (!/^(?:f|ht)tps?\:\/\//.test(url)) {
+        url = "https://" + url;
+    }
+    return new Handlebars.SafeString(url)
+});
+

--- a/app/assets/js/helpers.js
+++ b/app/assets/js/helpers.js
@@ -1,11 +1,14 @@
 Handlebars.registerHelper('cleanurl', function(url) {
-    var cleanurl = url.replace(/.*:\/\//,'').split(/[?#]/);
+    var currentpath = window.location.host + window.location.pathname;
+    var cleanurl = url.replace(/^\./, currentpath.substring(0, currentpath.lastIndexOf('/'))).replace(/.*:\/\//,'').split(/[?#]/);
     return new Handlebars.SafeString(cleanurl)
 });
 
 Handlebars.registerHelper('addprotocol', function(url) {
-    if (!/^(?:f|ht)tps?\:\/\//.test(url)) {
-        url = "https://" + url;
+    if (!/^\./.test(url)) {
+        if (!/^(?:f|ht)tps?\:\/\//.test(url)) {
+            url = "https://" + url;
+        }
     }
     return new Handlebars.SafeString(url)
 });

--- a/app/index.html
+++ b/app/index.html
@@ -85,8 +85,8 @@
                             <span class="iconify icon" data-icon="mdi-{{icon}}"></span>
                         </div>
                         <div class="apps_text">
-                            <a href="https://{{url}}">{{name}}</a>
-                            <span id="app-address">{{url}}</span>
+                            <a href="{{addprotocol url}}">{{name}}</a>
+                            <span id="app-address">{{cleanurl url}}</span>
                         </div>
                     </div>
                 {{/apps}}
@@ -117,6 +117,7 @@
         </a>
     </div>
 
+    <script src="./assets/js/helpers.js" type="text/javascript"></script>
     <script src="./assets/js/data.js" type="text/javascript"></script>
     <script src="./assets/js/script.js" type="text/javascript"></script>
     <script src="./assets/js/themer.js" type="text/javascript"></script>


### PR DESCRIPTION
This adds https:// only if the user did not provide a protocol in their config file. It removes the protocol from the URL when displaying underneath the app name.